### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,7 +72,7 @@ const config = {
           //   label: 'Tutorial',
           // },
           //{to: '/projects', label: 'Projects', position: 'left'},
-          {to: '/docs/paraskevas-leivadaros-resume.pdf', label: 'Resume', position: 'left'},
+          {to: '/paraskevas-leivadaros-resume.pdf', label: 'Resume', position: 'left'},
           {to: '/blog', label: 'Blog', position: 'right'},
           // {
           //   href: 'https://github.com/facebook/docusaurus',


### PR DESCRIPTION
This pull request makes a minor update to the navigation configuration in `docusaurus.config.js`. The change updates the path for the "Resume" link in the site's navbar to point to a different location.

* Changed the `to` path for the "Resume" navbar item from `/docs/paraskevas-leivadaros-resume.pdf` to `/paraskevas-leivadaros-resume.pdf` in `docusaurus.config.js`