### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,7 +72,7 @@ const config = {
           //   label: 'Tutorial',
           // },
           //{to: '/projects', label: 'Projects', position: 'left'},
-          {to: '/docs/paraskevas-leivadaros-resume.pdf', label: 'Resume', position: 'left'},
+          {href: '/docs/paraskevas-leivadaros-resume.pdf', label: 'Resume', position: 'left'},
           {to: '/blog', label: 'Blog', position: 'right'},
           // {
           //   href: 'https://github.com/facebook/docusaurus',


### PR DESCRIPTION
This pull request makes a small update to the navigation configuration in `docusaurus.config.js`. The change updates the "Resume" menu item to use an external link (`href`) instead of an internal route (`to`), ensuring proper navigation to the PDF file.

- Changed the "Resume" menu item in the navbar to use `href` instead of `to` for linking to the PDF, which is the correct approach for external files.